### PR TITLE
fix: Don't know user on first login

### DIFF
--- a/container-files/var/www/html/external-auth.patch
+++ b/container-files/var/www/html/external-auth.patch
@@ -51,7 +51,7 @@ index daddd74..3a47c7c 100644
      if (!empty($login)) {
        try {
          $query = "SELECT id, login, password, admin FROM " . self::db()->table('users') . " WHERE login = ? LIMIT 1";
-@@ -47,6 +47,11 @@ class uUser {
+@@ -47,6 +47,12 @@ class uUser {
          $stmt->bindColumn('admin', $this->isAdmin, PDO::PARAM_BOOL);
          if ($stmt->fetch(PDO::FETCH_BOUND)) {
            $this->isValid = true;

--- a/container-files/var/www/html/external-auth.patch
+++ b/container-files/var/www/html/external-auth.patch
@@ -58,6 +58,7 @@ index daddd74..3a47c7c 100644
 +	} elseif ($create) { // Create user if not found
 +	  $pass = random_bytes(16);
 +	  $this->id = $this->add($login, $pass);
++	  $this->login = $login;
 +	  $this->hash = password_hash($pass, PASSWORD_DEFAULT);
 +	  $this->isValid = true;
          }


### PR DESCRIPTION
Added a fix for when the user does not exist, during the first login the function does not set the ID. 